### PR TITLE
bugfix and alignment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+beautifulsoup4
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import find_packages, setup
 setup(
     name='toloka2python',
     install_requires=[
-        'requests',
+        'requests', 'beautifulsoup4'
     ],
     packages = ['toloka2python', 'toloka2python/models'],
-    version='0.1.0',
+    version='0.1.1',
     description='Бібліотека на пітоні для взаємодії з українським торрент-трекером Toloka',
     author='CakesTwix',
     license='GPL3',

--- a/toloka2python/models/torrent.py
+++ b/toloka2python/models/torrent.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any, List
 
 @dataclass
 class Torrent:
@@ -9,12 +10,21 @@ class Torrent:
     name: str = ""
     author: str = ""
     img: str = ""
+    thumbnail: str = ""
     torrent_name: str = ""
     date: str = ""
     size: str = ""
     thanks: int = ""
     rating: int = ""
     torrent_url: str = ""
+    files: List[Any] = None
+
+@dataclass
+class TorrentFile:
+    """Датаклас, який містить інформацію про Список файлів завантаження"""
+    folder_name: str = ""
+    file_name: str = ""
+    size: str = ""
 
 @dataclass
 class TorrentElement:

--- a/toloka2python/models/torrent.py
+++ b/toloka2python/models/torrent.py
@@ -3,15 +3,18 @@ from dataclasses import dataclass
 @dataclass
 class Torrent:
     """Датаклас, який містить інформацію про торрент"""
-    name: str
-    url: str
-    img: str
-    torrent_name: str
-    registered_date: str
-    size: str
-    thanks: int
-    rating: int
-    torrent_url: str
+    forum: str = ""
+    forum_url: str = ""
+    url: str = ""
+    name: str = ""
+    author: str = ""
+    img: str = ""
+    torrent_name: str = ""
+    date: str = ""
+    size: str = ""
+    thanks: int = ""
+    rating: int = ""
+    torrent_url: str = ""
 
 @dataclass
 class TorrentElement:
@@ -22,7 +25,7 @@ class TorrentElement:
     name: str
     author: str
     verify: bool
-    download_link: str
+    torrent_url: str
     size: str
     status: str
     seeders: int


### PR DESCRIPTION
спроба вирівняти і привести до одного формату Torrent і TorrentElement.
доповнено requirements.txt пропущеним пакетом
переформатовано дату до одного формату
виправлено дрібні баги з даними (наприклад, зайвий слеш у посиланні)
Torrent розширено з полем автора

як розширення, додано метод на пошук через офіційний апі